### PR TITLE
Modify default running period

### DIFF
--- a/cmd/secret-rotator/job.yaml
+++ b/cmd/secret-rotator/job.yaml
@@ -12,10 +12,10 @@ spec:
           name: config
       containers:
       - name: rot-container
-        image: gcr.io/k8s-jkns-gke-soak/secret-rotator:latest
+        image: gcr.io/k8s-staging-k8s-gsm-tools/secret-rotator:latest
         args:
         - --config-path=/tmp/config/rotConfig 
-        - --period=1000
+        - --period=60
         - --v=2
         volumeMounts:
         - name: config-volume

--- a/cmd/secret-rotator/main.go
+++ b/cmd/secret-rotator/main.go
@@ -42,7 +42,7 @@ func (o *options) Validate() error {
 func gatherOptions() options {
 	o := options{}
 	flag.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
-	flag.Int64Var(&o.period, "period", 1000, "Period in milliseconds.")
+	flag.Int64Var(&o.period, "period", 60, "Period in seconds.")
 	flag.BoolVar(&o.enableDeletion, "enable-deletion", false, "Enable deleting old secrets when deactivation triggered.")
 	flag.BoolVar(&o.runOnce, "run-once", false, "Rotate once instead of continuous loop.")
 	flag.Parse()
@@ -90,7 +90,7 @@ func main() {
 		Client:       secretManagerClient,
 		Agent:        configAgent,
 		Provisioners: provisioners,
-		Period:       time.Duration(o.period) * time.Millisecond,
+		Period:       time.Duration(o.period) * time.Second,
 		RunOnce:      o.runOnce,
 	}
 

--- a/cmd/secret-sync-controller/job.yaml
+++ b/cmd/secret-sync-controller/job.yaml
@@ -15,7 +15,7 @@ spec:
         image: gcr.io/k8s-staging-k8s-gsm-tools/secret-sync-controller:latest
         args:
         - --config-path=/tmp/config/syncConfig 
-        - --period=1000
+        - --period=60
         - --v=2
         volumeMounts:
         - name: config-volume

--- a/cmd/secret-sync-controller/main.go
+++ b/cmd/secret-sync-controller/main.go
@@ -43,7 +43,7 @@ func gatherOptions() options {
 	flag.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	flag.StringVar(&o.kubeconfig, "kubeconfig", "", "Path to kubeconfig file.")
 	flag.BoolVar(&o.runOnce, "run-once", false, "Sync once instead of continuous loop.")
-	flag.Int64Var(&o.resyncPeriod, "period", 1000, "Resync period in milliseconds.")
+	flag.Int64Var(&o.resyncPeriod, "period", 60, "Resync period in seconds.")
 	flag.Parse()
 	return o
 }
@@ -86,7 +86,7 @@ func main() {
 		Client:       clientInterface,
 		Agent:        configAgent,
 		RunOnce:      o.runOnce,
-		ResyncPeriod: time.Duration(o.resyncPeriod) * time.Millisecond,
+		ResyncPeriod: time.Duration(o.resyncPeriod) * time.Second,
 	}
 
 	stopChan := make(chan struct{})

--- a/experiment/cmd/consumer/job.yaml
+++ b/experiment/cmd/consumer/job.yaml
@@ -25,6 +25,6 @@ spec:
           mountPath: "/etc/secret-volume"
         args:
         - --mount-path=$(GOOGLE_APPLICATION_CREDENTIALS)
-        - --period=3000
+        - --period=3
         - --gsm-project=k8s-jkns-gke-soak
       restartPolicy: Never

--- a/experiment/cmd/consumer/main.go
+++ b/experiment/cmd/consumer/main.go
@@ -42,7 +42,7 @@ func gatherOptions() options {
 	flag.StringVar(&o.mountPath, "mount-path", "", "Path to mounted svc key.")
 	flag.StringVar(&o.outputPath, "output-path", "consumer_keys", "Output path for svc keys.")
 	flag.StringVar(&o.gsmProject, "gsm-project", "", "Secret Manager project.")
-	flag.Int64Var(&o.period, "period", 1000, "Period in milliseconds.")
+	flag.Int64Var(&o.period, "period", 3, "Period in seconds.")
 	flag.Parse()
 	return o
 }
@@ -71,7 +71,7 @@ func main() {
 
 	logger := logger.Logger{
 		Agent:   keysAgent,
-		Period:  time.Duration(o.period) * time.Millisecond,
+		Period:  time.Duration(o.period) * time.Second,
 		Project: o.gsmProject,
 	}
 

--- a/secret-rotator/svckey/svckey.go
+++ b/secret-rotator/svckey/svckey.go
@@ -33,17 +33,29 @@ func (svc ServiceAccountKeySpec) String() string {
 	return fmt.Sprintf("projects/%s/serviceAccounts/%s", svc.Project, svc.ServiceAccount)
 }
 
-// ServiceAccountKeySpec.Type() is used to obtain the provisioner of the ServiceAccountKey
+// Type is used to obtain the provisioner of the ServiceAccountKey
 func (svc ServiceAccountKeySpec) Type() string {
 	return "serviceAccountKey"
 }
 
-// ServiceAccountKeySpec.Labels() is used to obtain the labels needed for the provisioner of the ServiceAccountKey
+// Labels is used to obtain the labels needed for the provisioner of the ServiceAccountKey
 func (svc ServiceAccountKeySpec) Labels() map[string]string {
 	return map[string]string{
 		"project":         svc.Project,
 		"service-account": svc.ServiceAccount,
 	}
+}
+
+// Validate return error if 'project' and/or 'service-account' fields are missing
+func (svc *ServiceAccountKeySpec) Validate() error {
+	switch {
+	case svc.Project == "":
+		return fmt.Errorf("Missing <project> field")
+	case svc.ServiceAccount == "":
+		return fmt.Errorf("Missing <service-account> field")
+	}
+
+	return nil
 }
 
 // Provisioner is a GCP service account key provisioner.

--- a/secret-rotator/tests/mockclient.go
+++ b/secret-rotator/tests/mockclient.go
@@ -100,6 +100,19 @@ func (cl *MockClient) ValidateAndConvertVersion(project, id, version string) (st
 	return version, err
 }
 
+// CreateSecret creates an empty secret specified by project, id.
+// It returns nil if successful, otherwise error.
+func (cl *MockClient) CreateSecret(project, id string) error {
+	err := cl.ValidateProject(project)
+	if err != nil {
+		return err
+	}
+
+	cl.Secrets[project][id] = new(Secret)
+
+	return nil
+}
+
 // UpsertSecret adds a new version to the secret specified by project, id.
 // It inserts a new secret if id doesn't already exist.
 // If successful the latest version will have 'data' as its secret value,


### PR DESCRIPTION
Modified the default running periods for both the rotator and the
sync-controller to be 60 seconds.
Added a bootstrap method for non existing gsm secrets.